### PR TITLE
[a1][script][5/5] add run all script for tcp

### DIFF
--- a/a1/.env.template
+++ b/a1/.env.template
@@ -1,3 +1,5 @@
+# =========== DEPLOYMENT ===========
+
 # ur username on mimi man
 USER=your_username_on_mimi
 # in most cases, will be mimi.cs.mcgill.ca unless you want to target a specific node
@@ -6,3 +8,13 @@ REMOTE_HOST=mimi.cs.mcgill.ca
 REMOTE_FPATH=/home/2023/$USER
 # application implementation: rmi or tcp
 APP_TYPE=rmi
+
+# =========== RUNTIME ===========
+
+# rmi registry port should be a singular fixed value
+REGISTRY_PORT=1122
+# hostnames for each node, can literally be any node in the mimi cluster
+FLIGHT_HOST=tr-open-04
+CAR_HOST=tr-open-05
+ROOM_HOST=tr-open-06
+MIDDLEWARE_HOST=tr-open-07

--- a/a1/scripts/run_rmi.sh
+++ b/a1/scripts/run_rmi.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# this script is meant to be used on mimi
+# it assumes all build artifacts exist and are ready to use
+
+cd ..
+
+source .env
+echo "REGISTRY_PORT = $REGISTRY_PORT"
+echo "FLIGHT_HOST = $FLIGHT_HOST"
+echo "CAR_HOST = $CAR_HOST"
+echo "ROOM_HOST = $ROOM_HOST"
+echo "MIDDLEWARE_HOST = $MIDDLEWARE_HOST"
+
+set -ex
+
+
+# =========== RUN SERVERS ===========
+
+tmux kill-session -t a1 2>/dev/null || true
+tmux new-session -d -s a1 \; \
+    split-window -h \; \
+    split-window -v \; \
+    select-pane -t 0 \; \
+    split-window -v \; \
+    select-layout tiled
+
+tmux send-keys -t a1:0.1 "ssh -t ${FLIGHT_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; CLASSPATH=shared/build/classes/java/main rmiregistry -J-Djava.rmi.server.useCodebaseOnly=false 1122 & ./server/build/install/server/bin/server Flights\"" C-m
+tmux send-keys -t a1:0.2 "ssh -t ${CAR_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; CLASSPATH=shared/build/classes/java/main rmiregistry -J-Djava.rmi.server.useCodebaseOnly=false 1122 & ./server/build/install/server/bin/server Cars\"" C-m
+tmux send-keys -t a1:0.3 "ssh -t ${ROOM_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; CLASSPATH=shared/build/classes/java/main rmiregistry -J-Djava.rmi.server.useCodebaseOnly=false 1122 & ./server/build/install/server/bin/server Rooms\"" C-m
+
+
+# =========== RUN MIDDLEWARE ===========
+
+tmux send-keys -t a1:0.0 "ssh -t ${MIDDLEWARE_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; CLASSPATH=shared/build/classes/java/main rmiregistry -J-Djava.rmi.server.useCodebaseOnly=false 1122 & ./middleware/build/install/middleware/bin/middleware ${FLIGHT_HOST} ${CAR_HOST} ${ROOM_HOST}\"" C-m
+
+
+# =========== RUN CLIENT ===========
+
+./client/build/install/client/bin/client ${MIDDLEWARE_HOST} Middleware

--- a/a1/scripts/run_tcp.sh
+++ b/a1/scripts/run_tcp.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# this script is meant to be used on mimi
+# it assumes all build artifacts exist and are ready to use
+
+cd ..
+
+source .env
+echo "REGISTRY_PORT = $REGISTRY_PORT"
+echo "FLIGHT_HOST = $FLIGHT_HOST"
+echo "CAR_HOST = $CAR_HOST"
+echo "ROOM_HOST = $ROOM_HOST"
+echo "MIDDLEWARE_HOST = $MIDDLEWARE_HOST"
+
+set -ex
+
+
+# =========== RUN SERVERS ===========
+
+tmux kill-session -t a1 2>/dev/null || true
+tmux new-session -d -s a1 \; \
+    split-window -h \; \
+    split-window -v \; \
+    select-pane -t 0 \; \
+    split-window -v \; \
+    select-layout tiled
+
+tmux send-keys -t a1:0.1 "ssh -t ${FLIGHT_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; ./server/build/install/server/bin/server Flights\"" C-m
+tmux send-keys -t a1:0.2 "ssh -t ${CAR_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; ./server/build/install/server/bin/server Cars\"" C-m
+tmux send-keys -t a1:0.3 "ssh -t ${ROOM_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; ./server/build/install/server/bin/server Rooms\"" C-m
+
+
+# =========== RUN MIDDLEWARE ===========
+
+tmux send-keys -t a1:0.0 "ssh -t ${MIDDLEWARE_HOST} \"cd $(pwd) > /dev/null; echo -n 'Connected to '; hostname; ./middleware/build/install/middleware/bin/middleware ${FLIGHT_HOST} ${CAR_HOST} ${ROOM_HOST}\"" C-m
+
+
+# =========== RUN CLIENT ===========
+
+./client/build/install/client/bin/client ${MIDDLEWARE_HOST} Middleware


### PR DESCRIPTION

Summary:

same idea as run all script for rmi

Test Plan:
- builds and runs at top of stack
- unit tests pass

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/75).
* __->__ #75
* #74