### PR TITLE
[5/n][a2][paxos] add paxos msg and model primitives

### DIFF
--- a/a2/.gitignore
+++ b/a2/.gitignore
@@ -2,8 +2,8 @@ bin
 build
 .gradle
 .settings
-*.log
-*.lck
+*.log*
+*.lck*
 .project
 .env
 .class

--- a/a2/build.gradle.kts
+++ b/a2/build.gradle.kts
@@ -5,10 +5,11 @@ plugins {
 group = "comp512p2"
 version = "1.0.0"
 
+// Apply a specific Java toolchain to ease working on different environments.
 java {
-    // Use toolchain or compatibility for Java 8
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {

--- a/a2/comp512st/paxos/Models.java
+++ b/a2/comp512st/paxos/Models.java
@@ -1,0 +1,24 @@
+package paxos;
+
+import java.io.Serializable;
+
+record GameMove(Integer playerNum, char move) implements Serializable {}
+
+// Phase 1
+
+interface ProposeResult {}
+
+record ProposeSuccess() implements ProposeResult {}
+
+record ProposeSuccessWithMove(GameMove move) implements ProposeResult {}
+
+// someone got more motion than u, use smth greater than their ballot number next time lil bro
+record ProposeFailure(Long greaterBID) implements ProposeResult {}
+
+// Phase 2
+
+interface AcceptResult {}
+
+record AcceptSuccess() implements AcceptResult {}
+
+record AcceptFailure(Long greaterBID) implements AcceptResult {}

--- a/a2/comp512st/paxos/PaxosMessage.java
+++ b/a2/comp512st/paxos/PaxosMessage.java
@@ -1,0 +1,38 @@
+package paxos;
+
+import java.io.Serializable;
+
+interface PaxosMessage extends Serializable {}
+
+interface ProposerMessage extends PaxosMessage {}
+
+interface AcceptorMessage extends PaxosMessage {}
+
+record PaxosEnvelope<T extends PaxosMessage>(
+    String sender,
+    T message
+) implements Serializable {}
+
+// PHASE I
+
+record Propose(Long ballotId) implements ProposerMessage {}
+
+record Promise(
+    Long ballotId,
+    Long lastAcceptedBID,
+    GameMove lastAcceptedMove
+) implements AcceptorMessage {}
+
+record Refuse(Long ballotId) implements AcceptorMessage {}
+
+// PHASE II
+
+record AcceptRequest(Long ballotId, GameMove move) implements ProposerMessage {}
+
+record AcceptAck(Long ballotId) implements AcceptorMessage {}
+
+record Deny(Long ballotId) implements AcceptorMessage {}
+
+// PHASE III
+
+record Confirm(Long ballotId) implements ProposerMessage {}

--- a/a2/comp512st/tests/TreasureIslandAppAuto.java
+++ b/a2/comp512st/tests/TreasureIslandAppAuto.java
@@ -1,15 +1,18 @@
 package tests;
 
-import comp512.ti.*;
-import comp512.utils.*;
-import java.io.*;
-import java.time.*;
+import comp512.ti.TreasureIsland;
+import comp512.utils.FailCheck;
+import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.logging.*;
-import paxos.*;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import paxos.Paxos;
 
 public class TreasureIslandAppAuto implements Runnable {
 

--- a/a2/comp512st/tests/TreasureIslandAppAuto.java
+++ b/a2/comp512st/tests/TreasureIslandAppAuto.java
@@ -59,13 +59,15 @@ public class TreasureIslandAppAuto implements Runnable {
 
     public void run() {
         while (
-            keepExploring // TODO: Make sure all the remaining messages are processed in the case of a graceful shutdown.
-        ) {
+            keepExploring // TODO: Make sure all the remaining messages are processed in the case of a
+        ) // graceful shutdown.
+        {
             try {
                 Object[] info = (Object[]) paxos.acceptTOMsg();
                 logger.fine("Received :" + Arrays.toString(info));
                 move((Integer) info[0], (Character) info[1], updateDisplay);
-                //displayIsland(); //we do not want to keep constantly refreshing the output display.
+                // displayIsland(); //we do not want to keep constantly refreshing the output
+                // display.
             } catch (InterruptedException ie) {
                 if (keepExploring) logger.log(
                     Level.SEVERE,
@@ -164,8 +166,9 @@ public class TreasureIslandAppAuto implements Runnable {
         public String nextMove() {
             int moveid = rand.nextInt(maxmoves); // used to make a random move / fail.
             if (
-                maxmoves < 10 // for very small maxmoves, we do not want to fail quickly. So pick a larger number.
-            ) moveid = rand.nextInt(20);
+                maxmoves < 10 // for very small maxmoves, we do not want to fail quickly. So pick a larger
+            ) // number.
+            moveid = rand.nextInt(20);
 
             logger.fine("moveid = " + moveid);
 
@@ -220,14 +223,14 @@ public class TreasureIslandAppAuto implements Runnable {
         logger.setLevel(Level.FINE);
 
         /*
-		Handler consoleHandler = new ConsoleHandler();
-		//logger.setLevel(Level.WARNING);
-		//logger.setLevel(Level.INFO);
-		//logger.setLevel(Level.ALL);
-		consoleHandler.setLevel(Level.FINE);
-		logger.addHandler(consoleHandler);
-		logger.setUseParentHandlers(false);
-		*/
+         * Handler consoleHandler = new ConsoleHandler();
+         * //logger.setLevel(Level.WARNING);
+         * //logger.setLevel(Level.INFO);
+         * //logger.setLevel(Level.ALL);
+         * consoleHandler.setLevel(Level.FINE);
+         * logger.addHandler(consoleHandler);
+         * logger.setUseParentHandlers(false);
+         */
 
         // Send logging to a file.
         try {
@@ -300,7 +303,7 @@ public class TreasureIslandAppAuto implements Runnable {
                 case "U":
                 case "D": // Capture the move and broadcast it to everyone along with the player number.
                     // Remember, this should block till this move has been accepted by the majority.
-                    //	The logic for that should be built into the paxos module.
+                    // The logic for that should be built into the paxos module.
                     paxos.broadcastTOMsg(
                         new Object[] { playerNum, cmd.charAt(0) }
                     );
@@ -308,27 +311,32 @@ public class TreasureIslandAppAuto implements Runnable {
                 case "FI": // The process is to fail immediately.
                     failCheck.setFailurePoint(FailCheck.FailureType.IMMEDIATE);
                     break;
-                case "FRP": // The process is supposed to fail immediately when it receives a propose message.
+                case "FRP": // The process is supposed to fail immediately when it receives a propose
+                    // message.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.RECEIVEPROPOSE
                     );
                     break;
-                case "FSV": // The process is supposed to fail immediately after it sends a vote for leader election.
+                case "FSV": // The process is supposed to fail immediately after it sends a vote for leader
+                    // election.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERSENDVOTE
                     );
                     break;
-                case "FSP": // The process is supposed to fail immediately after it sends a proposal to become leader.
+                case "FSP": // The process is supposed to fail immediately after it sends a proposal to
+                    // become leader.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERSENDPROPOSE
                     );
                     break;
-                case "FOL": // The process is supposed to fail immediately after a majority has accepted it as the leader.
+                case "FOL": // The process is supposed to fail immediately after a majority has accepted it
+                    // as the leader.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERBECOMINGLEADER
                     );
                     break;
-                case "FMV": // The process is supposed to fail immediately after a majority has accepted it’s proposed value.
+                case "FMV": // The process is supposed to fail immediately after a majority has accepted
+                    // it’s proposed value.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERVALUEACCEPT
                     );
@@ -342,7 +350,8 @@ public class TreasureIslandAppAuto implements Runnable {
             }
         }
 
-        logger.info("Done with all my moves ..."); // we just chill for a bit to ensure we got all the messages from others before we shutdown.
+        logger.info("Done with all my moves ..."); // we just chill for a bit to ensure we got all the messages from
+        // others before we shutdown.
         // May have to increase this for higher maxmoves and smaller intervals.
         try {
             Thread.sleep(5000);
@@ -354,7 +363,8 @@ public class TreasureIslandAppAuto implements Runnable {
             );
         }
         ta.keepExploring = false;
-        ta.tiThread.join(1000); // Wait maximum 1s for the app to process any more incomming messages that was in the queue.
+        ta.tiThread.join(1000); // Wait maximum 1s for the app to process any more incomming messages that was
+        // in the queue.
         logger.info("Shutting down Paxos");
         paxos.shutdownPaxos(); // shutdown paxos.
         ta.tiThread.interrupt(); // interrupt the app thread if it has not terminated.

--- a/a2/comp512st/tiapp/TreasureIslandApp.java
+++ b/a2/comp512st/tiapp/TreasureIslandApp.java
@@ -1,12 +1,16 @@
 package tiapp;
 
-import comp512.ti.*;
-import comp512.utils.*;
-import java.io.*;
+import comp512.ti.TreasureIsland;
+import comp512.utils.FailCheck;
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
 import java.util.Arrays;
 import java.util.Scanner;
-import java.util.logging.*;
-import paxos.*;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import paxos.Paxos;
 
 public class TreasureIslandApp implements Runnable {
 

--- a/a2/justfile
+++ b/a2/justfile
@@ -6,4 +6,5 @@ run player_num:
     ./comp512st/tiapp/run_tiapp.sh {{player_num}}
 
 clean:
-    rm *.log
+    rm -f *.log*
+    rm -f *.lck*


### PR DESCRIPTION

Summary:

in our Paxos protocol, we send different types of message. define a common serializable interface and define records that implement that interface. we can make it sealed too if needed.

app layer sends game moves as an array, encapsulate using model obj. also include models for results of each round since they can return diff types -> e.g. propose can return nothing, or previously committed move, or higher ballot long...

lmk if you have any thoughts on making ts cleaner

Test Plan:

builds and runs at top of stack

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/93).
* #99
* #98
* #97
* #96
* #95
* #94
* __->__ #93
* #92
* #91
* #90
* #89