### PR TITLE
[7/n][a2][reader] add reader component

### DIFF
--- a/a2/.gitignore
+++ b/a2/.gitignore
@@ -2,8 +2,8 @@ bin
 build
 .gradle
 .settings
-*.log
-*.lck
+*.log*
+*.lck*
 .project
 .env
 .class

--- a/a2/build.gradle.kts
+++ b/a2/build.gradle.kts
@@ -5,10 +5,11 @@ plugins {
 group = "comp512p2"
 version = "1.0.0"
 
+// Apply a specific Java toolchain to ease working on different environments.
 java {
-    // Use toolchain or compatibility for Java 8
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {

--- a/a2/comp512st/paxos/GCLReader.java
+++ b/a2/comp512st/paxos/GCLReader.java
@@ -1,0 +1,103 @@
+package paxos;
+
+import comp512.gcl.GCL;
+import comp512.gcl.GCMessage;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+class GCLReader implements Runnable {
+
+    private GCL gcl;
+    private Logger logger;
+
+    private BlockingQueue<PaxosEnvelope<AcceptorMessage>> proposerInQ;
+    private BlockingQueue<PaxosEnvelope<ProposerMessage>> acceptorInQ;
+
+    private volatile Boolean running;
+    private Thread ingester;
+
+    GCLReader(GCL gcl, Logger logger) {
+        this.gcl = gcl;
+        this.logger = logger;
+
+        proposerInQ = new LinkedBlockingQueue<>();
+        acceptorInQ = new LinkedBlockingQueue<>();
+
+        running = true;
+        ingester = new Thread(this);
+
+        ingester.start();
+    }
+
+    public void run() {
+        while (running) {
+            try {
+                GCMessage msg = gcl.readGCMessage();
+                String sender = msg.senderProcess;
+                Object val = msg.val;
+
+                logger.info("Received message " + val + " from " + sender);
+
+                if (
+                    val instanceof Propose ||
+                    val instanceof AcceptRequest ||
+                    val instanceof Confirm
+                ) {
+                    logger.info(
+                        "Appending message " + val + " to acceptor inQ"
+                    );
+
+                    acceptorInQ.put(
+                        new PaxosEnvelope<ProposerMessage>(
+                            sender,
+                            (ProposerMessage) val
+                        )
+                    );
+                } else if (
+                    val instanceof Promise ||
+                    val instanceof Refuse ||
+                    val instanceof AcceptAck ||
+                    val instanceof Deny
+                ) {
+                    logger.info(
+                        "Appending message " + val + " to proposer inQ"
+                    );
+
+                    proposerInQ.put(
+                        new PaxosEnvelope<AcceptorMessage>(
+                            sender,
+                            (AcceptorMessage) val
+                        )
+                    );
+                } else {
+                    logger.warning(
+                        "Unknown message format from " + sender + ": " + msg
+                    );
+                }
+            } catch (InterruptedException e) {
+                logger.severe("Thread interrupted: " + e.getStackTrace());
+                System.exit(1);
+            }
+        }
+    }
+
+    PaxosEnvelope<AcceptorMessage> pollProposerQ() throws InterruptedException {
+        logger.info("Polling proposer inQ.");
+        return proposerInQ.poll(100, TimeUnit.MILLISECONDS);
+    }
+
+    PaxosEnvelope<ProposerMessage> consumeAcceptorQ()
+        throws InterruptedException {
+        logger.info("Consuming from acceptor inQ.");
+        return acceptorInQ.take();
+    }
+
+    void shutdown() throws InterruptedException {
+        running = false;
+        ingester.join(1000); // permit grace period
+        ingester.interrupt();
+        gcl.shutdownGCL();
+    }
+}

--- a/a2/comp512st/paxos/GCLWriter.java
+++ b/a2/comp512st/paxos/GCLWriter.java
@@ -1,0 +1,31 @@
+package paxos;
+
+import comp512.gcl.GCL;
+import java.util.List;
+import java.util.logging.Logger;
+
+class GCLWriter {
+
+    private GCL gcl;
+    private Logger logger;
+
+    GCLWriter(GCL gcl, Logger logger) {
+        this.gcl = gcl;
+        this.logger = logger;
+    }
+
+    void send(String destProcess, PaxosMessage msg) {
+        logger.info("Sending message " + msg + " to " + destProcess);
+        gcl.sendMsg(msg, destProcess);
+    }
+
+    void multicast(List<String> processes, PaxosMessage msg) {
+        logger.info("Multicasting message " + msg + " to " + processes);
+        gcl.multicastMsg(msg, processes.toArray(new String[0]));
+    }
+
+    void broadcast(PaxosMessage msg) {
+        logger.info("Broadcasting message " + msg + " to everyone else");
+        gcl.broadcastMsg(msg);
+    }
+}

--- a/a2/comp512st/paxos/Models.java
+++ b/a2/comp512st/paxos/Models.java
@@ -1,0 +1,24 @@
+package paxos;
+
+import java.io.Serializable;
+
+record GameMove(Integer playerNum, char move) implements Serializable {}
+
+// Phase 1
+
+interface ProposeResult {}
+
+record ProposeSuccess() implements ProposeResult {}
+
+record ProposeSuccessWithMove(GameMove move) implements ProposeResult {}
+
+// someone got more motion than u, use smth greater than their ballot number next time lil bro
+record ProposeFailure(Long greaterBID) implements ProposeResult {}
+
+// Phase 2
+
+interface AcceptResult {}
+
+record AcceptSuccess() implements AcceptResult {}
+
+record AcceptFailure(Long greaterBID) implements AcceptResult {}

--- a/a2/comp512st/paxos/PaxosMessage.java
+++ b/a2/comp512st/paxos/PaxosMessage.java
@@ -1,0 +1,38 @@
+package paxos;
+
+import java.io.Serializable;
+
+interface PaxosMessage extends Serializable {}
+
+interface ProposerMessage extends PaxosMessage {}
+
+interface AcceptorMessage extends PaxosMessage {}
+
+record PaxosEnvelope<T extends PaxosMessage>(
+    String sender,
+    T message
+) implements Serializable {}
+
+// PHASE I
+
+record Propose(Long ballotId) implements ProposerMessage {}
+
+record Promise(
+    Long ballotId,
+    Long lastAcceptedBID,
+    GameMove lastAcceptedMove
+) implements AcceptorMessage {}
+
+record Refuse(Long ballotId) implements AcceptorMessage {}
+
+// PHASE II
+
+record AcceptRequest(Long ballotId, GameMove move) implements ProposerMessage {}
+
+record AcceptAck(Long ballotId) implements AcceptorMessage {}
+
+record Deny(Long ballotId) implements AcceptorMessage {}
+
+// PHASE III
+
+record Confirm(Long ballotId) implements ProposerMessage {}

--- a/a2/comp512st/tests/TreasureIslandAppAuto.java
+++ b/a2/comp512st/tests/TreasureIslandAppAuto.java
@@ -1,15 +1,18 @@
 package tests;
 
-import comp512.ti.*;
-import comp512.utils.*;
-import java.io.*;
-import java.time.*;
+import comp512.ti.TreasureIsland;
+import comp512.utils.FailCheck;
+import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.logging.*;
-import paxos.*;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import paxos.Paxos;
 
 public class TreasureIslandAppAuto implements Runnable {
 

--- a/a2/comp512st/tests/TreasureIslandAppAuto.java
+++ b/a2/comp512st/tests/TreasureIslandAppAuto.java
@@ -59,13 +59,15 @@ public class TreasureIslandAppAuto implements Runnable {
 
     public void run() {
         while (
-            keepExploring // TODO: Make sure all the remaining messages are processed in the case of a graceful shutdown.
-        ) {
+            keepExploring // TODO: Make sure all the remaining messages are processed in the case of a
+        ) // graceful shutdown.
+        {
             try {
                 Object[] info = (Object[]) paxos.acceptTOMsg();
                 logger.fine("Received :" + Arrays.toString(info));
                 move((Integer) info[0], (Character) info[1], updateDisplay);
-                //displayIsland(); //we do not want to keep constantly refreshing the output display.
+                // displayIsland(); //we do not want to keep constantly refreshing the output
+                // display.
             } catch (InterruptedException ie) {
                 if (keepExploring) logger.log(
                     Level.SEVERE,
@@ -164,8 +166,9 @@ public class TreasureIslandAppAuto implements Runnable {
         public String nextMove() {
             int moveid = rand.nextInt(maxmoves); // used to make a random move / fail.
             if (
-                maxmoves < 10 // for very small maxmoves, we do not want to fail quickly. So pick a larger number.
-            ) moveid = rand.nextInt(20);
+                maxmoves < 10 // for very small maxmoves, we do not want to fail quickly. So pick a larger
+            ) // number.
+            moveid = rand.nextInt(20);
 
             logger.fine("moveid = " + moveid);
 
@@ -220,14 +223,14 @@ public class TreasureIslandAppAuto implements Runnable {
         logger.setLevel(Level.FINE);
 
         /*
-		Handler consoleHandler = new ConsoleHandler();
-		//logger.setLevel(Level.WARNING);
-		//logger.setLevel(Level.INFO);
-		//logger.setLevel(Level.ALL);
-		consoleHandler.setLevel(Level.FINE);
-		logger.addHandler(consoleHandler);
-		logger.setUseParentHandlers(false);
-		*/
+         * Handler consoleHandler = new ConsoleHandler();
+         * //logger.setLevel(Level.WARNING);
+         * //logger.setLevel(Level.INFO);
+         * //logger.setLevel(Level.ALL);
+         * consoleHandler.setLevel(Level.FINE);
+         * logger.addHandler(consoleHandler);
+         * logger.setUseParentHandlers(false);
+         */
 
         // Send logging to a file.
         try {
@@ -300,7 +303,7 @@ public class TreasureIslandAppAuto implements Runnable {
                 case "U":
                 case "D": // Capture the move and broadcast it to everyone along with the player number.
                     // Remember, this should block till this move has been accepted by the majority.
-                    //	The logic for that should be built into the paxos module.
+                    // The logic for that should be built into the paxos module.
                     paxos.broadcastTOMsg(
                         new Object[] { playerNum, cmd.charAt(0) }
                     );
@@ -308,27 +311,32 @@ public class TreasureIslandAppAuto implements Runnable {
                 case "FI": // The process is to fail immediately.
                     failCheck.setFailurePoint(FailCheck.FailureType.IMMEDIATE);
                     break;
-                case "FRP": // The process is supposed to fail immediately when it receives a propose message.
+                case "FRP": // The process is supposed to fail immediately when it receives a propose
+                    // message.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.RECEIVEPROPOSE
                     );
                     break;
-                case "FSV": // The process is supposed to fail immediately after it sends a vote for leader election.
+                case "FSV": // The process is supposed to fail immediately after it sends a vote for leader
+                    // election.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERSENDVOTE
                     );
                     break;
-                case "FSP": // The process is supposed to fail immediately after it sends a proposal to become leader.
+                case "FSP": // The process is supposed to fail immediately after it sends a proposal to
+                    // become leader.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERSENDPROPOSE
                     );
                     break;
-                case "FOL": // The process is supposed to fail immediately after a majority has accepted it as the leader.
+                case "FOL": // The process is supposed to fail immediately after a majority has accepted it
+                    // as the leader.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERBECOMINGLEADER
                     );
                     break;
-                case "FMV": // The process is supposed to fail immediately after a majority has accepted it’s proposed value.
+                case "FMV": // The process is supposed to fail immediately after a majority has accepted
+                    // it’s proposed value.
                     failCheck.setFailurePoint(
                         FailCheck.FailureType.AFTERVALUEACCEPT
                     );
@@ -342,7 +350,8 @@ public class TreasureIslandAppAuto implements Runnable {
             }
         }
 
-        logger.info("Done with all my moves ..."); // we just chill for a bit to ensure we got all the messages from others before we shutdown.
+        logger.info("Done with all my moves ..."); // we just chill for a bit to ensure we got all the messages from
+        // others before we shutdown.
         // May have to increase this for higher maxmoves and smaller intervals.
         try {
             Thread.sleep(5000);
@@ -354,7 +363,8 @@ public class TreasureIslandAppAuto implements Runnable {
             );
         }
         ta.keepExploring = false;
-        ta.tiThread.join(1000); // Wait maximum 1s for the app to process any more incomming messages that was in the queue.
+        ta.tiThread.join(1000); // Wait maximum 1s for the app to process any more incomming messages that was
+        // in the queue.
         logger.info("Shutting down Paxos");
         paxos.shutdownPaxos(); // shutdown paxos.
         ta.tiThread.interrupt(); // interrupt the app thread if it has not terminated.

--- a/a2/comp512st/tiapp/TreasureIslandApp.java
+++ b/a2/comp512st/tiapp/TreasureIslandApp.java
@@ -1,12 +1,16 @@
 package tiapp;
 
-import comp512.ti.*;
-import comp512.utils.*;
-import java.io.*;
+import comp512.ti.TreasureIsland;
+import comp512.utils.FailCheck;
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
 import java.util.Arrays;
 import java.util.Scanner;
-import java.util.logging.*;
-import paxos.*;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import paxos.Paxos;
 
 public class TreasureIslandApp implements Runnable {
 

--- a/a2/justfile
+++ b/a2/justfile
@@ -6,4 +6,5 @@ run player_num:
     ./comp512st/tiapp/run_tiapp.sh {{player_num}}
 
 clean:
-    rm *.log
+    rm -f *.log*
+    rm -f *.lck*


### PR DESCRIPTION

Summary:

refer to previous diff for more context. this diff implements the reader component.

reader maintains a queue for proposer to ingest from and another for acceptor to ingest from.

why? because GCL only submits 1 message. if we had 2 readers (1 for proposer, 1 for acceptor), then they might end up 'fighting' for msgs. consider the case where a message is sent and reader1 picks up the msg before reader2. since there is now no more messages coming in, reader2 is blocked and the component holding reader2 is halted.

we could implement a message duplicator to read from the GCL and duplicate each message, but I leave that up to the reviewer to decide.

Test Plan:

it builds and runs at top of stack

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/95).
* #99
* #98
* #97
* #96
* __->__ #95
* #94
* #93
* #92
* #91
* #90
* #89