### PR TITLE
[1/n][a2][tester] add test cmds and mod test scripts

### DIFF
--- a/a2/.env.template
+++ b/a2/.env.template
@@ -1,1 +1,2 @@
 BASEDIR=/path/to/comp512p2.jar
+AUTOTESTHOST=$(hostname)

--- a/a2/comp512st/tests/TreasureIslandAppAuto.java
+++ b/a2/comp512st/tests/TreasureIslandAppAuto.java
@@ -357,7 +357,7 @@ public class TreasureIslandAppAuto implements Runnable {
         // others before we shutdown.
         // May have to increase this for higher maxmoves and smaller intervals.
         try {
-            Thread.sleep(5000);
+            Thread.sleep(30_000);
         } catch (InterruptedException ie) {
             logger.log(
                 Level.SEVERE,

--- a/a2/comp512st/tests/run_tiapp_auto.sh
+++ b/a2/comp512st/tests/run_tiapp_auto.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-#TODO set this to where your code and jar file root dir is
-BASEDIR=$HOME/comp512/p2
-
 #TODO update your group number here in place of XX
-group=xx
+group=22
 
 #TODO Optional
 # this will always generate the same game island. Change the last digits to any number if you want to change it to a different island map. Otherwise leave it as it is.
@@ -12,7 +9,7 @@ gameid=game-$group-99
 
 #TODO edit these entries to put the name of the server that you are using and the associated ports.
 # Remember to start the script from this host
-export autotesthost=tr-open-01.cs.mcgill.ca
+export autotesthost=$AUTOTESTHOST
 # player1 -> process 1, player 2 -> process 2, etc .. add more depending on how many players are playing.
 # Script automatically counts the variables to figure out the number of players.
 export process1=${autotesthost}:401$group
@@ -26,7 +23,9 @@ export process3=${autotesthost}:403$group
 #export process9=${autotesthost}:409$group
 
 #TODO update these values as needed
-maxmoves=100 interval=100 randseed=xxxxxxxxx
+maxmoves="$MAXMOVES"
+interval="$INTERVAL"
+randseed="$SEED"
 #TODO IF (and only if) you want to simulate failures, enable this for corresponding player numbers.
 #export failmode_N=RECEIVEPROPOSE
 #export failmode_N=AFTERSENDVOTE
@@ -81,8 +80,8 @@ playernum=1
 for process in $(echo $processgroup | sed -e 's/,/ /g')
 do
 	failmode=$(env | grep '^failmode_'${playernum}'=' | sed -e 's/.*=//')
-	echo java comp512st.tests.TreasureIslandAppAuto $process $processgroup $gameid $numplayers $playernum $maxmoves $interval $randseed$playernum $failmode '>' $gameid-$playernum-display.log
-	java comp512st.tests.TreasureIslandAppAuto $process $processgroup $gameid $numplayers $playernum $maxmoves $interval $randseed$playernum $failmode  > $gameid-$playernum-display.log 2>&1 &
+	echo java comp512st.tests.TreasureIslandAppAuto $process $processgroup $gameid $numplayers $playernum $maxmoves $interval $randseed $playernum $failmode '>' $gameid-$playernum-display.log
+	java -cp "$BASEDIR/build/classes/java/main:$BASEDIR/comp512p2.jar" tests.TreasureIslandAppAuto $process $processgroup $gameid $numplayers $playernum $maxmoves $interval $randseed$playernum $failmode  > $gameid-$playernum-display.log 2>&1 &
 	playernum=$(expr $playernum + 1);
 done
 wait

--- a/a2/justfile
+++ b/a2/justfile
@@ -1,10 +1,20 @@
 build:
     ./gradlew clean build
 
-run player_num:
-    source .env && \
-    ./comp512st/tiapp/run_tiapp.sh {{player_num}}
-
 clean:
     rm -f *.log*
     rm -f *.lck*
+
+run player_num:
+    just build && \
+    source .env && \
+    ./comp512st/tiapp/run_tiapp.sh {{player_num}}
+
+kill:
+    pkill -f "comp512p2.jar" || true
+
+auto-test:
+    just kill && \
+    just build && \
+    source .env && \
+    ./comp512st/tests/run_tiapp_auto.sh


### PR DESCRIPTION

Summary:

buff just cmds

increase sleep duration in TreasureIslandAppAuto.java to prevent process from shutting down before others have completed execution (which would cause a halt)

move bash script vars to env

Test Plan:

just test

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/100).
* #135
* #134
* #133
* #132
* #108
* #107
* #106
* #105
* #104
* #103
* #102
* #101
* __->__ #100