### PR TITLE
[3/n][a2][scripts] source env in run scripts instead of just cmd

### DIFF
--- a/a2/.env.template
+++ b/a2/.env.template
@@ -1,2 +1,3 @@
 BASEDIR=/path/to/comp512p2.jar
+USER=mimi_user
 AUTOTESTHOST=$(hostname)

--- a/a2/comp512st/tests/run_tiapp_auto.sh
+++ b/a2/comp512st/tests/run_tiapp_auto.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a
+source "$SCRIPT_DIR/../../.env"
+set +a
+
 #TODO update your group number here in place of XX
 group=22
 
@@ -9,7 +14,7 @@ gameid=game-$group-99
 
 #TODO edit these entries to put the name of the server that you are using and the associated ports.
 # Remember to start the script from this host
-export autotesthost=$AUTOTESTHOST
+export autotesthost="$AUTOTESTHOST"
 # player1 -> process 1, player 2 -> process 2, etc .. add more depending on how many players are playing.
 # Script automatically counts the variables to figure out the number of players.
 export process1=${autotesthost}:401$group
@@ -33,7 +38,7 @@ randseed="$SEED"
 #export failmode_N=AFTERBECOMINGLEADER
 #export failmode_N=AFTERVALUEACCEPT
 #For example this enabled failmode AFTERBECOMINGLEADER for player/process 2 (only one failmode can be set per process). It is important to have the export.
-export failmode_2=AFTERBECOMINGLEADER
+# export failmode_2=AFTERBECOMINGLEADER
 
 # Check if this script is being exectuted on the correct server.
 if [[ $autotesthost != $(hostname) ]]

--- a/a2/comp512st/tiapp/run_tiapp.sh
+++ b/a2/comp512st/tiapp/run_tiapp.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a
+source "$SCRIPT_DIR/../../.env"
+set +a
+
 if [[ $# -ne 1 ]]
 then
 	echo "Please pass the player number as the argument"

--- a/a2/justfile
+++ b/a2/justfile
@@ -7,7 +7,6 @@ clean:
 
 run player_num:
     just build && \
-    source .env && \
     ./comp512st/tiapp/run_tiapp.sh {{player_num}}
 
 kill:
@@ -16,7 +15,6 @@ kill:
 auto-test:
     just kill && \
     just build && \
-    source .env && \
     ./comp512st/tests/run_tiapp_auto.sh
 
 deploy:

--- a/a2/justfile
+++ b/a2/justfile
@@ -18,3 +18,7 @@ auto-test:
     just build && \
     source .env && \
     ./comp512st/tests/run_tiapp_auto.sh
+
+deploy:
+    just build
+    ./scripts/deploy.sh

--- a/a2/scripts/deploy.sh
+++ b/a2/scripts/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source .env
+scp -r ./build/classes/* $(USER)@mimi.cs.mcgill.ca:~/comp-512/a2/build/classes


### PR DESCRIPTION

Summary:

source .env directly in each script so we don't have to deal with exports

Test Plan:

just run 1
just auto-test

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/102).
* #135
* #134
* #133
* #132
* #108
* #107
* #106
* #105
* #104
* #103
* __->__ #102
* #101