### PR TITLE
[7/n][a2][paxos] add coordinator component

### DIFF
--- a/a2/comp512st/paxos/Acceptor.java
+++ b/a2/comp512st/paxos/Acceptor.java
@@ -12,6 +12,7 @@ class Acceptor implements Runnable {
 
     private GCLReader reader;
     private GCLWriter writer;
+    private PaxosCoordinator coordinator;
     private Logger logger;
 
     private BlockingQueue<GameMove> moveQ = new LinkedBlockingQueue<>();
@@ -19,13 +20,19 @@ class Acceptor implements Runnable {
     private Thread ingester;
     private volatile Boolean running = true;
 
-    Acceptor(GCLReader reader, GCLWriter writer, Logger logger) {
+    Acceptor(
+        GCLReader reader,
+        GCLWriter writer,
+        PaxosCoordinator coordinator,
+        Logger logger
+    ) {
         maxBID = -1L;
         lastAcceptedBID = -1L;
         move = null;
 
         this.reader = reader;
         this.writer = writer;
+        this.coordinator = coordinator;
         this.logger = logger;
 
         ingester = new Thread(this);
@@ -134,6 +141,13 @@ class Acceptor implements Runnable {
             moveQ.offer(move);
         }
 
+        logger.info(
+            "Signaling completion for round with ballot ID " +
+                msg.ballotId() +
+                " and move " +
+                move
+        );
+        coordinator.signalRoundCompletion(msg.ballotId());
         move = null; // reset value
     }
 

--- a/a2/comp512st/paxos/Paxos.java
+++ b/a2/comp512st/paxos/Paxos.java
@@ -15,6 +15,7 @@ public class Paxos {
 
     private GCL gcl;
     private Logger logger;
+    private PaxosCoordinator coordinator;
     private Proposer proposer;
     private Acceptor acceptor;
     private Long ballotCounter;
@@ -28,12 +29,13 @@ public class Paxos {
     ) throws IOException, UnknownHostException {
         this.gcl = new GCL(myProcess, allGroupProcesses, null, logger);
         this.logger = logger;
+        this.coordinator = new PaxosCoordinator(logger);
 
         GCLReader reader = new GCLReader(gcl, logger);
         GCLWriter writer = new GCLWriter(gcl, logger);
         Integer majority = (allGroupProcesses.length / 2) + 1;
         proposer = new Proposer(majority, reader, writer, logger);
-        acceptor = new Acceptor(reader, writer, logger);
+        acceptor = new Acceptor(reader, writer, coordinator, logger);
 
         ballotCounter = 0L;
         // Rember to call the failCheck.checkFailure(..) with appropriate arguments throughout your Paxos code to force fail points if necessary.
@@ -43,16 +45,18 @@ public class Paxos {
     // This is what the application layer is going to call to send a message/value, such as the player and the move
     // Extend this to build whatever Paxos logic you need to make sure the messaging system is total order.
     // Here you will have to ensure that the CALL BLOCKS, and is returned ONLY when a majority (and immediately upon majority) of processes have accepted the value.
-    public void broadcastTOMsg(Object[] val) {
+    public void broadcastTOMsg(Object[] val) throws InterruptedException {
         Long ballotId = ballotCounter;
         GameMove myMove = new GameMove((Integer) val[0], (Character) val[1]);
         GameMove proposedMove = myMove;
+
+        Integer baseDelayMs = 50;
 
         while (myMove != null) {
             // Phase 1 - propose self as leader
             ballotId = incrementAndGetBallotCounter();
             logger.info(
-                "Initiating new round, proposing self as leader with ballot ID" +
+                "Initiating new round, proposing self as leader with ballot ID " +
                     ballotId
             );
 
@@ -63,12 +67,29 @@ public class Paxos {
                     proposedMove = s.move(); // use previous move
                 }
                 case ProposeFailure f -> {
-                    ballotCounter = f.greaterBID();
+                    logger.info(
+                        "Lost proposer phase with ballot ID " +
+                            ballotId +
+                            ", awaiting end of current round..."
+                    );
+
+                    coordinator.awaitRoundCompletion();
+
+                    Long highestConfirmedBID =
+                        coordinator.getHighestConfirmedBallot();
+                    Long highestRefuseBID = f.ballotId();
+                    if (Long.compare(ballotCounter, highestConfirmedBID) < 0) {
+                        ballotCounter = highestConfirmedBID;
+                    }
+                    if (Long.compare(ballotCounter, highestRefuseBID) < 0) {
+                        ballotCounter = highestRefuseBID;
+                    }
+
                     continue; // retry
                 }
                 default -> {
                     // nuke the system
-                    logger.severe("Something went terribly wrong.");
+                    logger.severe("Shake yo booty");
                     System.exit(1);
                 }
             }
@@ -83,7 +104,24 @@ public class Paxos {
             switch (accRes) {
                 case AcceptSuccess s -> {} // do nothing
                 case AcceptFailure f -> {
-                    ballotCounter = f.greaterBID();
+                    logger.info(
+                        "Lost accept requests phase with ballod ID " +
+                            ballotId +
+                            ", awaiting end of current round..."
+                    );
+
+                    coordinator.awaitRoundCompletion();
+
+                    Long highestConfirmedBID =
+                        coordinator.getHighestConfirmedBallot();
+                    Long highestDenyBID = f.ballotId();
+                    if (Long.compare(ballotCounter, highestConfirmedBID) < 0) {
+                        ballotCounter = highestConfirmedBID;
+                    }
+                    if (Long.compare(ballotCounter, highestDenyBID) < 0) {
+                        ballotCounter = highestDenyBID;
+                    }
+
                     continue; // retry
                 }
                 default -> {
@@ -103,6 +141,8 @@ public class Paxos {
             }
 
             proposer.sendConfirms(ballotId);
+            // force winner to wait as well
+            coordinator.awaitRoundCompletion();
 
             // all done
             break;

--- a/a2/comp512st/paxos/PaxosCoordinator.java
+++ b/a2/comp512st/paxos/PaxosCoordinator.java
@@ -1,0 +1,66 @@
+package paxos;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+
+class PaxosCoordinator {
+
+    private Logger logger;
+
+    private ReentrantLock lock = new ReentrantLock();
+    private Condition roundOver = lock.newCondition();
+    private boolean roundCompleted = false;
+    private Long highestConfirmedBallot;
+
+    PaxosCoordinator(Logger logger) {
+        this.logger = logger;
+
+        highestConfirmedBallot = -1L;
+    }
+
+    void awaitRoundCompletion() throws InterruptedException {
+        lock.lock();
+        try {
+            while (!roundCompleted) {
+                roundOver.await();
+            }
+            logger.fine("Round completed. Resetting 'roundCompleted' flag.");
+            roundCompleted = false; // reset for next round
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void signalRoundCompletion(Long confirmedBID) {
+        lock.lock();
+        try {
+            logger.info("Lock acquired. Signaling round completion.");
+
+            if (Long.compare(highestConfirmedBallot, confirmedBID) < 0) {
+                highestConfirmedBallot = confirmedBID;
+                logger.info(
+                    "Updated highestKnownBallot to " +
+                        this.highestConfirmedBallot
+                );
+            }
+
+            roundCompleted = true;
+            roundOver.signalAll();
+            logger.info(
+                "Condition 'roundOver' signaled to all waiting threads."
+            );
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    Long getHighestConfirmedBallot() {
+        lock.lock();
+        try {
+            return highestConfirmedBallot;
+        } finally {
+            lock.unlock();
+        }
+    }
+}


### PR DESCRIPTION

Summary:

coordinator signals whenever round is complete

proposers will await end of current round instead of immediately retrying if they fail to get majority

Test Plan:

just auto-test

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/106).
* #135
* #134
* #133
* #132
* #108
* #107
* __->__ #106