### PR TITLE
[7/n][a3][manager] add manager impl + watchers + callbacks

### DIFF
--- a/a3/dist/src/main/java/DistProcess.java
+++ b/a3/dist/src/main/java/DistProcess.java
@@ -1,10 +1,4 @@
-import interfaces.DistTask;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -161,59 +155,6 @@ public class DistProcess implements Watcher, AsyncCallback.ChildrenCallback {
         logger.info("DISTAPP : processResult : {} : {} : {}", rc, path, ctx);
         for (String child : children) {
             logger.debug(child);
-            try {
-                // TODO There is quite a bit of worker specific activities here,
-                // that should be moved done by a process function as the worker.
-
-                // TODO!! This is not a good approach, you should get the data using an async
-                // version of the API.
-                byte[] taskSerial = zk.getData(
-                    String.format("/dist%d/tasks/%s", id, child),
-                    false,
-                    null
-                );
-
-                // Re-construct our task object.
-                ByteArrayInputStream bis = new ByteArrayInputStream(taskSerial);
-                ObjectInput in = new ObjectInputStream(bis);
-                DistTask dt = (DistTask) in.readObject();
-
-                // Execute the task.
-                // TODO: Again, time consuming stuff. Should be done by some other thread and
-                // not inside a callback!
-                dt.compute();
-
-                // Serialize our Task object back to a byte array!
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                ObjectOutputStream oos = new ObjectOutputStream(bos);
-                oos.writeObject(dt);
-                oos.flush();
-                taskSerial = bos.toByteArray();
-
-                // Store it inside the result node.
-                zk.create(
-                    String.format("/dist%d/tasks/%s/result", id, child),
-                    taskSerial,
-                    Ids.OPEN_ACL_UNSAFE,
-                    CreateMode.PERSISTENT
-                );
-                // zk.create(
-                // String.format("/dist%d/tasks/%s/result", groupNum, child),
-                // ("Hello from " + pinfo).getBytes(),
-                // Ids.OPEN_ACL_UNSAFE,
-                // CreateMode.PERSISTENT
-                // );
-            } catch (NodeExistsException nee) {
-                logger.error(nee.toString());
-            } catch (KeeperException ke) {
-                logger.error(ke.toString());
-            } catch (InterruptedException ie) {
-                logger.error(ie.toString());
-            } catch (IOException io) {
-                logger.error(io.toString());
-            } catch (ClassNotFoundException cne) {
-                logger.error(cne.toString());
-            }
         }
     }
 

--- a/a3/dist/src/main/java/manager/DistManager.java
+++ b/a3/dist/src/main/java/manager/DistManager.java
@@ -1,0 +1,179 @@
+package manager;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import manager.callback.TasksChildrenCallback;
+import manager.callback.WorkerDataCallback;
+import manager.callback.WorkersChildrenCallback;
+import manager.watcher.TasksWatcher;
+import manager.watcher.WorkerDataWatcher;
+import manager.watcher.WorkersWatcher;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import role.DistRole;
+
+public class DistManager implements DistRole {
+
+    private static Logger logger = LoggerFactory.getLogger(DistManager.class);
+
+    private ZooKeeper zk;
+    private Integer groupNum;
+
+    private TasksWatcher tasksWatcher;
+    private TasksChildrenCallback tasksChildrenCallback;
+
+    private WorkersWatcher workersWatcher;
+    private WorkersChildrenCallback workersChildrenCallback;
+
+    private WorkerDataWatcher workerDataWatcher;
+    private WorkerDataCallback workerDataCallback;
+
+    private ExecutorService executor;
+
+    private Set<String> seenWorkers;
+    private Queue<String> idleWorkers;
+    private Set<String> seenTasks;
+    private Queue<String> pendingTasks;
+
+    public DistManager(ZooKeeper zk, Integer groupNum) {
+        this.zk = zk;
+        this.groupNum = groupNum;
+
+        String tasksPath = String.format("/dist%d/tasks", groupNum);
+        tasksWatcher = new TasksWatcher(this, tasksPath);
+        tasksChildrenCallback = new TasksChildrenCallback(this);
+
+        String workersPath = String.format("/dist%d/workers", groupNum);
+        workersWatcher = new WorkersWatcher(this, workersPath);
+        workersChildrenCallback = new WorkersChildrenCallback(this);
+
+        workerDataWatcher = new WorkerDataWatcher(this);
+        workerDataCallback = new WorkerDataCallback(this);
+
+        executor = Executors.newSingleThreadExecutor();
+
+        seenWorkers = new HashSet<>();
+        idleWorkers = new LinkedBlockingQueue<>();
+        seenTasks = new HashSet<>();
+        pendingTasks = new LinkedBlockingQueue<>();
+    }
+
+    public void setWatch() {
+        setWorkersWatch();
+        setTasksWatch();
+    }
+
+    public void setWorkersWatch() {
+        String path = String.format("/dist%d/workers", groupNum);
+        zk.getChildren(path, workersWatcher, workersChildrenCallback, null);
+
+        logger.info("Manager set watch to {}", path);
+    }
+
+    public void setWorkerDataWatch(String workerNode) {
+        String path = String.format("/dist%d/workers/%s", groupNum, workerNode);
+        zk.getData(path, workerDataWatcher, workerDataCallback, workerNode);
+
+        logger.info("Manager set watch to worker at {}", path);
+    }
+
+    public void setTasksWatch() {
+        String path = String.format("/dist%d/tasks", groupNum);
+        zk.getChildren(path, tasksWatcher, tasksChildrenCallback, null);
+
+        logger.info("Manager set watch to {}", path);
+    }
+
+    public void handleTasksChildrenChange(List<String> tasks) {
+        for (String task : tasks) {
+            if (!seenTasks.contains(task)) {
+                seenTasks.add(task);
+                pendingTasks.add(task);
+
+                logger.info("New task `{}` found!", task);
+            }
+        }
+
+        executor.submit(this::assignTasks);
+    }
+
+    public void handleWorkersChildrenChange(List<String> workers) {
+        for (String worker : workers) {
+            if (!seenWorkers.contains(worker)) {
+                seenWorkers.add(worker);
+                idleWorkers.add(worker);
+
+                logger.info("New worker `{}` found!", worker);
+
+                // set watch on new worker's data
+                setWorkerDataWatch(worker);
+            }
+        }
+
+        executor.submit(this::assignTasks);
+    }
+
+    public void handleWorkerDataChange(byte[] data, String worker) {
+        // worker data indicates idle status
+        if (data.length == 0) {
+            idleWorkers.add(worker);
+        }
+    }
+
+    private void assignTasks() {
+        while (!pendingTasks.isEmpty() && !idleWorkers.isEmpty()) {
+            String task = pendingTasks.peek();
+            String worker = idleWorkers.peek();
+
+            if (task == null) {
+                logger.warn("No available task in queue...");
+                break;
+            }
+
+            if (worker == null) {
+                logger.warn("No idle workers available to execute task...");
+                break;
+            }
+
+            logger.info("Assigning task " + task + " to worker " + worker);
+
+            String workerPath = String.format(
+                "/dist%d/workers/%s",
+                groupNum,
+                worker
+            );
+            byte[] data = task.getBytes();
+
+            try {
+                zk.setData(workerPath, data, -1);
+
+                // If successful, remove from queues
+                pendingTasks.poll();
+                idleWorkers.poll();
+            } catch (KeeperException.NoNodeException nne) {
+                logger.warn(
+                    "Worker {} crashed during task assignment, removing from queue...",
+                    worker
+                );
+                idleWorkers.poll();
+            } catch (KeeperException ke) {
+                logger.error(ke.toString());
+                break;
+            } catch (InterruptedException ie) {
+                logger.error(ie.toString());
+                break;
+            }
+        }
+    }
+
+    public void onShutdown() {
+        executor.shutdown();
+    }
+}

--- a/a3/dist/src/main/java/manager/callback/TasksChildrenCallback.java
+++ b/a3/dist/src/main/java/manager/callback/TasksChildrenCallback.java
@@ -1,0 +1,23 @@
+package manager.callback;
+
+import java.util.List;
+import manager.DistManager;
+import org.apache.zookeeper.AsyncCallback;
+
+public class TasksChildrenCallback implements AsyncCallback.ChildrenCallback {
+
+    private DistManager manager;
+
+    public TasksChildrenCallback(DistManager manager) {
+        this.manager = manager;
+    }
+
+    public void processResult(
+        int rc,
+        String path,
+        Object ctx,
+        List<String> children
+    ) {
+        manager.handleTasksChildrenChange(children);
+    }
+}

--- a/a3/dist/src/main/java/manager/callback/WorkerDataCallback.java
+++ b/a3/dist/src/main/java/manager/callback/WorkerDataCallback.java
@@ -1,0 +1,25 @@
+package manager.callback;
+
+import manager.DistManager;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.data.Stat;
+
+public class WorkerDataCallback implements AsyncCallback.DataCallback {
+
+    private DistManager manager;
+
+    public WorkerDataCallback(DistManager manager) {
+        this.manager = manager;
+    }
+
+    public void processResult(
+        int rc,
+        String path,
+        Object ctx,
+        byte[] data,
+        Stat stat
+    ) {
+        String worker = (String) ctx;
+        manager.handleWorkerDataChange(data, worker);
+    }
+}

--- a/a3/dist/src/main/java/manager/callback/WorkersChildrenCallback.java
+++ b/a3/dist/src/main/java/manager/callback/WorkersChildrenCallback.java
@@ -1,0 +1,23 @@
+package manager.callback;
+
+import java.util.List;
+import manager.DistManager;
+import org.apache.zookeeper.AsyncCallback;
+
+public class WorkersChildrenCallback implements AsyncCallback.ChildrenCallback {
+
+    private DistManager manager;
+
+    public WorkersChildrenCallback(DistManager manager) {
+        this.manager = manager;
+    }
+
+    public void processResult(
+        int rc,
+        String path,
+        Object ctx,
+        List<String> children
+    ) {
+        manager.handleWorkersChildrenChange(children);
+    }
+}

--- a/a3/dist/src/main/java/manager/watcher/TasksWatcher.java
+++ b/a3/dist/src/main/java/manager/watcher/TasksWatcher.java
@@ -1,0 +1,29 @@
+package manager.watcher;
+
+import manager.DistManager;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class TasksWatcher implements Watcher {
+
+    private DistManager manager;
+    private String watchPath;
+
+    public TasksWatcher(DistManager manager, String watchPath) {
+        this.manager = manager;
+        this.watchPath = watchPath;
+    }
+
+    public void process(WatchedEvent event) {
+        // manager should be notified if any new child znodes are added
+        if (
+            event.getType() == Watcher.Event.EventType.NodeChildrenChanged &&
+            event.getPath().equals(watchPath)
+        ) {
+            // There has been changes to the children of the node.
+            // We are going to re-install the Watch as well as request for the list of the
+            // children.
+            manager.setTasksWatch();
+        }
+    }
+}

--- a/a3/dist/src/main/java/manager/watcher/WorkerDataWatcher.java
+++ b/a3/dist/src/main/java/manager/watcher/WorkerDataWatcher.java
@@ -1,0 +1,24 @@
+package manager.watcher;
+
+import manager.DistManager;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class WorkerDataWatcher implements Watcher {
+
+    private DistManager manager;
+
+    public WorkerDataWatcher(DistManager manager) {
+        this.manager = manager;
+    }
+
+    public void process(WatchedEvent event) {
+        if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+            // parse path to get worker
+            String path = event.getPath();
+            String worker = path.substring(path.lastIndexOf("/") + 1);
+
+            manager.setWorkerDataWatch(worker);
+        }
+    }
+}

--- a/a3/dist/src/main/java/manager/watcher/WorkersWatcher.java
+++ b/a3/dist/src/main/java/manager/watcher/WorkersWatcher.java
@@ -1,0 +1,29 @@
+package manager.watcher;
+
+import manager.DistManager;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class WorkersWatcher implements Watcher {
+
+    private DistManager manager;
+    private String watchPath;
+
+    public WorkersWatcher(DistManager manager, String watchPath) {
+        this.manager = manager;
+        this.watchPath = watchPath;
+    }
+
+    public void process(WatchedEvent event) {
+        // manager should be notified if any new child znodes are added
+        if (
+            event.getType() == Watcher.Event.EventType.NodeChildrenChanged &&
+            event.getPath().equals(watchPath)
+        ) {
+            // There has been changes to the children of the node.
+            // We are going to re-install the Watch as well as request for the list of the
+            // children.
+            manager.setWorkersWatch();
+        }
+    }
+}

--- a/a3/dist/src/main/java/role/DistRole.java
+++ b/a3/dist/src/main/java/role/DistRole.java
@@ -1,0 +1,6 @@
+package role;
+
+public interface DistRole {
+    public void setWatch();
+    public void onShutdown();
+}

--- a/a3/dist/src/main/java/worker/DistWorker.java
+++ b/a3/dist/src/main/java/worker/DistWorker.java
@@ -1,0 +1,154 @@
+package worker;
+
+import interfaces.DistTask;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import role.DistRole;
+import worker.callback.TaskDataCallback;
+import worker.callback.WorkerDataCallback;
+import worker.watcher.WorkerWatcher;
+
+public class DistWorker implements DistRole, Runnable {
+
+    private static Logger logger = LoggerFactory.getLogger(DistWorker.class);
+
+    ZooKeeper zk;
+    Integer groupNum;
+    String workerName;
+
+    WorkerWatcher workerWatcher;
+    WorkerDataCallback workerDataCallback;
+
+    TaskDataCallback taskDataCallback;
+
+    private ExecutorService executor;
+
+    public DistWorker(ZooKeeper zk, Integer groupNum, String workerName) {
+        this.zk = zk;
+        this.groupNum = groupNum;
+        this.workerName = workerName;
+
+        workerWatcher = new WorkerWatcher(this);
+        workerDataCallback = new WorkerDataCallback(this);
+
+        taskDataCallback = new TaskDataCallback(this);
+
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    public void run() {}
+
+    public void setWatch() {
+        // set watch on own node
+        String path = String.format("/dist%d/workers/%s", groupNum, workerName);
+        zk.getData(path, workerWatcher, workerDataCallback, null);
+
+        logger.info("Worker set watch to {}", path);
+    }
+
+    // when worker gets assigned a new task
+    public void handleWorkerDataChange(byte[] workerData) {
+        executor.submit(() -> {
+            // if data is empty byte array, worker is idle
+            if (workerData.length > 0) {
+                String taskNode = new String(
+                    workerData,
+                    StandardCharsets.UTF_8
+                );
+
+                logger.info(
+                    "Worker `{}` received task `{}`",
+                    taskNode,
+                    workerName
+                );
+
+                // fetch znode data from task node
+                String path = String.format(
+                    "/dist%d/tasks/%s",
+                    groupNum,
+                    taskNode
+                );
+
+                logger.info("Fetching data from task node at `{}`", path);
+
+                zk.getData(path, null, taskDataCallback, taskNode);
+            }
+        });
+    }
+
+    // received task data -> compute and create result node
+    public void handleTaskData(byte[] taskData, String taskNode) {
+        executor.submit(() -> {
+            try {
+                // Re-construct our task object.
+                ByteArrayInputStream bis = new ByteArrayInputStream(taskData);
+                ObjectInput in = new ObjectInputStream(bis);
+                DistTask task = (DistTask) in.readObject();
+
+                logger.info("Worker computing task...");
+                task.compute();
+                logger.info("Worker done with task...");
+
+                // Serialize our Task object back to a byte array!
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos);
+                oos.writeObject(task);
+                oos.flush();
+
+                byte[] resultData = bos.toByteArray();
+
+                // Store it inside the result node.
+                String resultPath = String.format(
+                    "/dist%d/tasks/%s/result",
+                    groupNum,
+                    taskNode
+                );
+
+                logger.info("Creating result node at path `{}`", resultPath);
+
+                zk.create(
+                    resultPath,
+                    resultData,
+                    Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT
+                );
+
+                // set own worker data back to empty byte array
+                String workerPath = String.format(
+                    "/dist%d/workers/%s",
+                    groupNum,
+                    workerName
+                );
+                zk.setData(workerPath, new byte[0], -1);
+            } catch (NodeExistsException nee) {
+                logger.error(nee.toString());
+            } catch (KeeperException ke) {
+                logger.error(ke.toString());
+            } catch (InterruptedException ie) {
+                logger.error(ie.toString());
+            } catch (IOException io) {
+                logger.error(io.toString());
+            } catch (ClassNotFoundException cne) {
+                logger.error(cne.toString());
+            }
+        });
+    }
+
+    public void onShutdown() {
+        executor.shutdown();
+    }
+}

--- a/a3/dist/src/main/java/worker/callback/TaskDataCallback.java
+++ b/a3/dist/src/main/java/worker/callback/TaskDataCallback.java
@@ -1,0 +1,25 @@
+package worker.callback;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.data.Stat;
+import worker.DistWorker;
+
+public class TaskDataCallback implements AsyncCallback.DataCallback {
+
+    private DistWorker worker;
+
+    public TaskDataCallback(DistWorker worker) {
+        this.worker = worker;
+    }
+
+    public void processResult(
+        int rc,
+        String path,
+        Object ctx,
+        byte[] data,
+        Stat stat
+    ) {
+        String taskNode = (String) ctx;
+        worker.handleTaskData(data, taskNode);
+    }
+}

--- a/a3/dist/src/main/java/worker/callback/WorkerDataCallback.java
+++ b/a3/dist/src/main/java/worker/callback/WorkerDataCallback.java
@@ -1,0 +1,24 @@
+package worker.callback;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.data.Stat;
+import worker.DistWorker;
+
+public class WorkerDataCallback implements AsyncCallback.DataCallback {
+
+    private DistWorker worker;
+
+    public WorkerDataCallback(DistWorker worker) {
+        this.worker = worker;
+    }
+
+    public void processResult(
+        int rc,
+        String path,
+        Object ctx,
+        byte[] data,
+        Stat stat
+    ) {
+        worker.handleWorkerDataChange(data);
+    }
+}

--- a/a3/dist/src/main/java/worker/watcher/WorkerWatcher.java
+++ b/a3/dist/src/main/java/worker/watcher/WorkerWatcher.java
@@ -1,0 +1,20 @@
+package worker.watcher;
+
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import worker.DistWorker;
+
+public class WorkerWatcher implements Watcher {
+
+    private DistWorker worker;
+
+    public WorkerWatcher(DistWorker worker) {
+        this.worker = worker;
+    }
+
+    public void process(WatchedEvent event) {
+        if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+            worker.setWatch();
+        }
+    }
+}


### PR DESCRIPTION

Summary:

manager watches children of tasks and workers

also watches data of each individual worker in the pool

whenever tasks children change, manager filters out new tasks and tries to assign them

whenever workers children change, manger filters out new workers and tries to assign them any outstanding tasks

whenever data of a worker changes from busy (contains task node name) to idle (empty byte array), manager tries to assign this newly idle worker work

callbacks and watchers are kinda spaghetti rn

Test Plan:

it builds

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/158).
* #170
* #169
* #168
* #167
* #166
* #165
* #164
* #163
* #162
* #161
* #160
* #159
* __->__ #158
* #157