### PR TITLE
[2/2][a3][just] add cmds for Trottier nodes

### DIFF
--- a/a3/.env.template
+++ b/a3/.env.template
@@ -1,3 +1,5 @@
+MIMI_USER=mimi-user
+
 # comma separated string of host:port of zk ensemble
 ZKSERVER=tr-open-01.cs.mcgill.ca:2181,tr-open-02.cs.mcgill.ca:2181,tr-open-03.cs.mcgill.ca:2181
 GROUP_NUM=22

--- a/a3/justfile
+++ b/a3/justfile
@@ -10,14 +10,14 @@ run-dist:
     ./gradlew :dist:run
 
 zk-cli:
-    zkCli -server localhost:2181
+    zkCli -server $ZKSERVER
 
 clean-zk:
-    zkCli -server localhost:2181 <<< "deleteall /dist22"
+    zkCli -server $ZKSERVER <<< "deleteall /dist22"
 
-    zkCli -server localhost:2181 <<< "create /dist22"
-    zkCli -server localhost:2181 <<< "create /dist22/workers"
-    zkCli -server localhost:2181 <<< "create /dist22/tasks"
+    zkCli -server $ZKSERVER <<< "create /dist22"
+    zkCli -server $ZKSERVER <<< "create /dist22/workers"
+    zkCli -server $ZKSERVER <<< "create /dist22/tasks"
 
 deploy:
     just build-all
@@ -33,3 +33,10 @@ deploy:
     # shared
     scp -r ./shared/bin "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/shared"
     scp -r ./shared/build "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/shared"
+
+# following commands are meant for usage on trottier nodes
+run-dist-tr:
+    ./scripts/runDist.sh
+
+run-client-tr samples:
+    ./scripts/runClient.sh {{samples}}

--- a/a3/justfile
+++ b/a3/justfile
@@ -18,3 +18,18 @@ clean-zk:
     zkCli -server localhost:2181 <<< "create /dist22"
     zkCli -server localhost:2181 <<< "create /dist22/workers"
     zkCli -server localhost:2181 <<< "create /dist22/tasks"
+
+deploy:
+    just build-all
+
+    # client
+    scp -r ./client/bin "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/client"
+    scp -r ./client/build "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/client"
+
+    # dist
+    scp -r ./dist/bin "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/dist"
+    scp -r ./dist/build "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/dist"
+
+    # shared
+    scp -r ./shared/bin "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/shared"
+    scp -r ./shared/build "$MIMI_USER@mimi.cs.mcgill.ca:/home/2023/$MIMI_USER/comp-512/a3/shared"

--- a/a3/scripts/runClient.sh
+++ b/a3/scripts/runClient.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export ZKSERVER
+export GROUP_NUM
+export ZOOCFGDIR=""
+export ZOOCFG=""
+
+# Ensure exactly one argument was provided
+if [ "$#" -ne 1 ]; then
+    echo "Error: Invalid number of arguments."
+    exit 1
+fi
+
+# Ensure the argument is a positive integer
+if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: <samples> must be a positive integer."
+    exit 1
+fi
+
+source $ZOOBINDIR/zkEnv.sh
+java -cp "$CLASSPATH:client/bin/main:shared/bin/main:." DistClient {{samples}}

--- a/a3/scripts/runDist.sh
+++ b/a3/scripts/runDist.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export ZKSERVER
+export GROUP_NUM
+export ZOOCFGDIR=""
+export ZOOCFG=""
+
+. $ZOOBINDIR/zkEnv.sh
+java -cp "$CLASSPATH:dist/bin/main:shared/bin/main:." DistProcess


### PR DESCRIPTION

Summary:

don't want to use gradle run task because of cache lock contention on mimi

mimi uses some weird network file system so only one gradle process can hold the lock at a time... if we want to "truly" distribute our processes over different nodes, we need native java commands

Test Plan:

just run-dist-tr
just run-client-tr

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/raydatray/comp-512/pull/172).
* __->__ #172
* #171